### PR TITLE
Add: visualization of heuristic scores (including collocation score) w.r.t. a given instance

### DIFF
--- a/cobweb/cached_string.hpp
+++ b/cobweb/cached_string.hpp
@@ -62,6 +62,12 @@ namespace std {
 
 // functions for printing CachedString-related objects
 template <typename V>
+std::ostream& operator<<(std::ostream& os, const CachedString &s) {
+    os << s.get_string();
+    return os;
+}
+
+template <typename V>
 std::ostream& operator<<(std::ostream& os, const std::unordered_map<CachedString, V>& map) {
     os << "{";
     for (auto it = map.begin(); it != map.end(); ++it) {

--- a/cobweb/cobweb.cpp
+++ b/cobweb/cobweb.cpp
@@ -28,6 +28,9 @@ namespace pybind11 {
 #else
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/complex.h>
+#include <pybind11/functional.h>
+#include <pybind11/chrono.h>
 #endif
 
 namespace py = pybind11;
@@ -315,6 +318,10 @@ class CobwebTree {
             this->root = new CobwebNode();
             this->root->tree = this;
             this->attr_vals = AV_KEY_TYPE();
+        }
+        
+        void set_seed(int seed) {
+            gen.seed(seed);
         }
 
         std::string __str__(){
@@ -2661,6 +2668,7 @@ inline double CobwebNode::log_prob_instance_missing(const AV_COUNT_TYPE &instanc
             .def("__str__", &CobwebTree::__str__)
             .def("dump_json", &CobwebTree::dump_json)
             .def("load_json", &CobwebTree::load_json)
+            .def("set_seed", &CobwebTree::set_seed)
             .def_readonly("root", &CobwebTree::root, py::return_value_policy::reference);
     }
 #endif

--- a/cobweb/cobweb.cpp
+++ b/cobweb/cobweb.cpp
@@ -2046,6 +2046,9 @@ inline std::string CobwebNode::sum_square_to_json() {
         ret += "\"" + attr.get_string() + "\": " + doubleToString(cnt);
         // std::to_string(cnt);
     }
+
+    ret += "}";
+    return ret;
 }
 
 inline std::string CobwebNode::dump_json() {
@@ -2705,6 +2708,8 @@ double heuristic_fn(const int heuristic, const AV_COUNT_TYPE &instance, CobwebNo
                     if (curr->av_count.at(attr).count(val))
                         dot_product += P_av * curr->av_count.at(attr).at(val);
                 }
+                assert (P_sum_square > 1e-10);
+                if (Q_sum_square < 1e-10) return 0.;
                 similarity *= dot_product / sqrt(P_sum_square) / sqrt(Q_sum_square);
             }
             return similarity;

--- a/cobweb/cobweb.cpp
+++ b/cobweb/cobweb.cpp
@@ -302,13 +302,15 @@ class CobwebTree {
         bool norm_attributes;
         CobwebNode *root;
         AV_KEY_TYPE attr_vals;
+        bool disable_splitting;
 
-        CobwebTree(float alpha, bool weight_attr, int objective, bool children_norm, bool norm_attributes) {
+        CobwebTree(float alpha, bool weight_attr, int objective, bool children_norm, bool norm_attributes, bool disable_splitting = false) {
             this->alpha = alpha;
             this->weight_attr = weight_attr;
             this->objective = objective;
             this->children_norm = children_norm;
             this->norm_attributes = norm_attributes;
+            this->disable_splitting = disable_splitting;
 
             this->root = new CobwebNode();
             this->root->tree = this;
@@ -1282,7 +1284,7 @@ inline std::tuple<double, int> CobwebNode::get_best_operation(
                     MERGE));
     }
 
-    if (best1->children.size() > 0) {
+    if (best1->children.size() > 0 and this->tree->disable_splitting == false) {
         operations.push_back(std::make_tuple(pu_for_split(best1),
                     custom_rand(),
                     SPLIT));
@@ -2538,12 +2540,13 @@ inline double CobwebNode::log_prob_instance_missing(const AV_COUNT_TYPE &instanc
             .def_readonly("tree", &CobwebNode::tree, py::return_value_policy::reference);
 
         py::class_<CobwebTree>(m, "CobwebTree")
-            .def(py::init<float, bool, int, bool, bool>(),
+            .def(py::init<float, bool, int, bool, bool, bool>(),
                     py::arg("alpha") = 1.0,
                     py::arg("weight_attr") = false,
                     py::arg("objective") = 0,
                     py::arg("children_norm") = true,
-                    py::arg("norm_attributes") = false)
+                    py::arg("norm_attributes") = false,
+                    py::arg("disable_splitting") = false)
             .def("ifit", &CobwebTree::ifit, py::return_value_policy::reference)
             .def("fit", &CobwebTree::fit,
                     py::arg("instances") = std::vector<AV_COUNT_TYPE>(),

--- a/cobweb/cobweb.cpp
+++ b/cobweb/cobweb.cpp
@@ -300,9 +300,9 @@ class CobwebTree {
         int objective;
         bool children_norm;
         bool norm_attributes;
+        bool disable_splitting;
         CobwebNode *root;
         AV_KEY_TYPE attr_vals;
-        bool disable_splitting;
 
         CobwebTree(float alpha, bool weight_attr, int objective, bool children_norm, bool norm_attributes, bool disable_splitting = false) {
             this->alpha = alpha;
@@ -423,6 +423,7 @@ class CobwebTree {
             output += "\"objective\": " + std::to_string(this->objective) + ",\n";
             output += "\"children_norm\": " + std::to_string(this->children_norm) + ",\n";
             output += "\"norm_attributes\": " + std::to_string(this->norm_attributes) + ",\n";
+            output += "\"disable_splitting\": " + std::to_string(this->disable_splitting) + ",\n";
             output += "\"root\": " + this->root->dump_json();
             output += "}\n";
 
@@ -458,9 +459,14 @@ class CobwebTree {
             struct json_object_element_s* norm_attributes_obj = children_norm_obj->next;
             bool norm_attributes = bool(atoi(json_value_as_number(norm_attributes_obj->value)->number));
             this->norm_attributes = norm_attributes;
+            
+            // disable_splitting
+            struct json_object_element_s* disable_splitting_obj = norm_attributes_obj->next;
+            bool disable_splitting = bool(atoi(json_value_as_number(disable_splitting_obj->value)->number));
+            this->disable_splitting = disable_splitting;
 
             // root
-            struct json_object_element_s* root_obj = norm_attributes_obj->next;
+            struct json_object_element_s* root_obj = disable_splitting_obj->next;
             struct json_object_s* root = json_value_as_object(root_obj->value);
 
             delete this->root;

--- a/cobweb/visualize.py
+++ b/cobweb/visualize.py
@@ -49,7 +49,7 @@ def _gen_viz(js_ob, dst, recreate_html):
         webbrowser.open('file://' + realpath(viz_file))
 
 
-def visualize(tree, dst=None, recreate_html=True):
+def visualize(tree, dst=None, recreate_html=True, instance=None, heuristic=5):
     """
     Create an interactive visualization of a concept_formation tree and open
     it in your browswer.
@@ -62,15 +62,19 @@ def visualize(tree, dst=None, recreate_html=True):
     :param tree: A category tree to visualize
     :param dst: A directory to generate visualization files into. If None no
         files will be generated
-    :param create_html: A flag for whether new supporting html files should be
+    :param recreate_html: A flag for whether new supporting html files should be
         created
     :type tree: :class:`CobwebTree <concept_formation.cobweb.CobwebTree>`,
         :class:`Cobweb3Tree <concept_formation.cobweb3.Cobweb3Tree>`, or
         :class:`TrestleTree <concept_formation.trestle.TrestleTree>`
     :type dst: str
-    :type create_html: bool
+    :type recreate_html: bool
     """
-    _gen_viz(tree.root.output_json(), dst, recreate_html)
+    _gen_viz(
+        tree.root.output_json() if instance is None else tree.root.output_json_w_heuristics(instance, heuristic), 
+        dst, 
+        recreate_html
+    )
 
 
 # begin Modification 


### PR DESCRIPTION
- Add: visualization of multi-node prediction using heuristic scores (including collocation score, cosine similarity, mean square error, KL-divergence ... ) w.r.t. a given instance

**(To use, just add `instance=instance, heuristic=0-8` to visualize())** See [here](https://github.com/Teachable-AI-Lab/cobweb/pull/4/files#r1763465236)

(Yellow means higher score)
<img width="950" alt="image" src="https://github.com/user-attachments/assets/00dca04b-f2b7-4563-8231-00130936bd3b">

- Rename: obtain_representation -> obtain_description
- Add: disable_splitting option
- Add: set_seed() for reproducibility